### PR TITLE
Implement mempool admission checks and queue modes

### DIFF
--- a/blockchain_demo/mempool.py
+++ b/blockchain_demo/mempool.py
@@ -1,19 +1,47 @@
-from typing import List
+from typing import Dict, List, Optional, Set
 from .transaction import Transaction
+from . import dsl
+from .config import CFG
 
 class Mempool:
-    def __init__(self, mode: str = "premium"):
-        self.mode = mode
+    def __init__(self, balances: Optional[Dict[str, int]] = None, mode: Optional[str] = None):
+        self.mode = mode or CFG.TX_QUEUE_MODE
         self._seq = 0
         self.txs: List[tuple[int, Transaction]] = []
+        self.tx_hashes: Set[str] = set()
+        self.nonces: Dict[str, int] = {}
+        self.balances = balances or {}
 
-    def add_tx(self, tx: Transaction):
+    def add_tx(self, tx: Transaction) -> bool:
+        # verify signature
+        if not tx.verify():
+            return False
+        # verify nonce monotonic per address
+        if tx.nonce <= self.nonces.get(tx.from_addr, 0):
+            return False
+        # verify balance sufficient for premium
+        if self.balances.get(tx.from_addr, 0) < tx.premium:
+            return False
+        # pre-parse DSL script
+        try:
+            dsl.parse_script(tx.script)
+        except Exception:
+            return False
+        tx_hash = tx.hash()
+        if tx_hash in self.tx_hashes:
+            return False
+
         self.txs.append((self._seq, tx))
+        self.tx_hashes.add(tx_hash)
+        self.nonces[tx.from_addr] = tx.nonce
         self._seq += 1
         if self.mode == "premium":
             self.txs.sort(key=lambda item: (-item[1].premium, item[0]))
+        return True
 
     def pop_for_block(self, cap: int) -> List[Transaction]:
         selected_pairs = self.txs[:cap]
         self.txs = self.txs[cap:]
+        for _, tx in selected_pairs:
+            self.tx_hashes.discard(tx.hash())
         return [tx for _, tx in selected_pairs]

--- a/tests/test_mempool.py
+++ b/tests/test_mempool.py
@@ -1,0 +1,60 @@
+import os
+from blockchain_demo.mempool import Mempool
+from blockchain_demo.transaction import Transaction
+from blockchain_demo import wallet
+
+
+def create_wallet(tmp_path):
+    path = os.path.join(tmp_path, 'w.json')
+    return wallet.generate_wallet(path, local_role='user')
+
+
+def test_add_tx_checks_signature_nonce_balance(tmp_path):
+    w = create_wallet(tmp_path)
+    balances = {w['public_key']: 5}
+    mp = Mempool(balances=balances, mode='premium')
+    tx = Transaction(from_addr=w['public_key'], script='let x=1', premium=2, nonce=1)
+    tx.sign(w)
+    assert mp.add_tx(tx) is True
+    # duplicate hash rejected
+    assert mp.add_tx(tx) is False
+    # wrong signature
+    w2 = create_wallet(tmp_path)
+    tx2 = Transaction(from_addr=w['public_key'], script='let x=1', premium=2, nonce=2)
+    tx2.sign(w2)
+    assert mp.add_tx(tx2) is False
+    # low balance
+    tx3 = Transaction(from_addr=w['public_key'], script='let x=1', premium=10, nonce=2)
+    tx3.sign(w)
+    assert mp.add_tx(tx3) is False
+    # nonce not monotonic
+    tx4 = Transaction(from_addr=w['public_key'], script='let x=1', premium=1, nonce=1)
+    tx4.sign(w)
+    assert mp.add_tx(tx4) is False
+
+
+def test_queue_modes(tmp_path):
+    w1 = create_wallet(tmp_path)
+    w2 = create_wallet(tmp_path)
+    balances = {w1['public_key']: 100, w2['public_key']: 100}
+    # premium mode
+    mp = Mempool(balances=balances, mode='premium')
+    tx1 = Transaction(from_addr=w1['public_key'], script='let a=1', premium=1, nonce=1)
+    tx1.sign(w1)
+    mp.add_tx(tx1)
+    tx2 = Transaction(from_addr=w2['public_key'], script='let a=1', premium=5, nonce=1)
+    tx2.sign(w2)
+    mp.add_tx(tx2)
+    ordered = mp.pop_for_block(2)
+    assert [t.premium for t in ordered] == [5, 1]
+    # fifo mode
+    mp2 = Mempool(balances=balances, mode='fifo')
+    tx3 = Transaction(from_addr=w1['public_key'], script='let a=1', premium=1, nonce=1)
+    tx3.sign(w1)
+    mp2.add_tx(tx3)
+    tx4 = Transaction(from_addr=w2['public_key'], script='let a=1', premium=5, nonce=1)
+    tx4.sign(w2)
+    mp2.add_tx(tx4)
+    ordered2 = mp2.pop_for_block(2)
+    assert [t.premium for t in ordered2] == [1, 5]
+


### PR DESCRIPTION
## Summary
- enforce signature, nonce and balance checks in the mempool
- add duplicate transaction filtering
- support configuration-driven premium/fifo ordering
- add unit tests for transaction admission and ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791dd94af88325afef3b5fe9e99367