### PR TITLE
Implement transaction validations and canonical hashing

### DIFF
--- a/blockchain_demo/block.py
+++ b/blockchain_demo/block.py
@@ -7,6 +7,7 @@ from math import ceil
 from .wallet import verify
 from .transaction import Transaction
 from . import dsl
+from .utils import canonical_bytes
 
 
 def sha256d(data: bytes) -> str:
@@ -50,7 +51,7 @@ class Block:
         }
 
     def hash(self):
-        data = json.dumps(self.canonical_dict(), separators=(",", ":"), sort_keys=True).encode()
+        data = canonical_bytes(self.canonical_dict())
         return sha256d(data)
 
     @classmethod

--- a/blockchain_demo/mempool.py
+++ b/blockchain_demo/mempool.py
@@ -1,19 +1,40 @@
-from typing import List
+from typing import Dict, List, Optional, Set
+
 from .transaction import Transaction
+from .config import CFG
+
 
 class Mempool:
-    def __init__(self, mode: str = "premium"):
-        self.mode = mode
+    """In-memory queue tracking pending transactions."""
+
+    def __init__(self, balances: Optional[Dict[str, int]] = None, mode: Optional[str] = None, cfg=CFG):
+        self.mode = mode or CFG.TX_QUEUE_MODE
         self._seq = 0
         self.txs: List[tuple[int, Transaction]] = []
+        self.tx_hashes: Set[str] = set()
+        self.nonces: Dict[str, int] = {}
+        self.balances = balances or {}
+        self.cfg = cfg
 
-    def add_tx(self, tx: Transaction):
+    def add_tx(self, tx: Transaction) -> bool:
+        """Validate and enqueue a transaction."""
+        last_nonce = self.nonces.get(tx.from_addr, 0)
+        if not tx.validate(self.balances, last_nonce, self.cfg):
+            return False
+        tx_hash = tx.hash()
+        if tx_hash in self.tx_hashes:
+            return False
         self.txs.append((self._seq, tx))
+        self.tx_hashes.add(tx_hash)
+        self.nonces[tx.from_addr] = tx.nonce
         self._seq += 1
         if self.mode == "premium":
             self.txs.sort(key=lambda item: (-item[1].premium, item[0]))
+        return True
 
     def pop_for_block(self, cap: int) -> List[Transaction]:
         selected_pairs = self.txs[:cap]
         self.txs = self.txs[cap:]
+        for _, tx in selected_pairs:
+            self.tx_hashes.discard(tx.hash())
         return [tx for _, tx in selected_pairs]

--- a/blockchain_demo/utils.py
+++ b/blockchain_demo/utils.py
@@ -1,0 +1,6 @@
+import json
+from typing import Any
+
+def canonical_bytes(data: Any) -> bytes:
+    """Return canonical JSON representation as bytes."""
+    return json.dumps(data, separators=(",", ":"), sort_keys=True).encode()

--- a/tests/test_mempool.py
+++ b/tests/test_mempool.py
@@ -1,0 +1,60 @@
+import os
+from blockchain_demo.mempool import Mempool
+from blockchain_demo.transaction import Transaction
+from blockchain_demo import wallet
+
+
+def create_wallet(tmp_path):
+    path = os.path.join(tmp_path, 'w.json')
+    return wallet.generate_wallet(path, local_role='user')
+
+
+def test_add_tx_checks_signature_nonce_balance(tmp_path):
+    w = create_wallet(tmp_path)
+    balances = {w['public_key']: 5}
+    mp = Mempool(balances=balances, mode='premium')
+    tx = Transaction(from_addr=w['public_key'], script='let x=1', premium=2, nonce=1)
+    tx.sign(w)
+    assert mp.add_tx(tx) is True
+    # duplicate hash rejected
+    assert mp.add_tx(tx) is False
+    # wrong signature
+    w2 = create_wallet(tmp_path)
+    tx2 = Transaction(from_addr=w['public_key'], script='let x=1', premium=2, nonce=2)
+    tx2.sign(w2)
+    assert mp.add_tx(tx2) is False
+    # low balance
+    tx3 = Transaction(from_addr=w['public_key'], script='let x=1', premium=10, nonce=2)
+    tx3.sign(w)
+    assert mp.add_tx(tx3) is False
+    # nonce not monotonic
+    tx4 = Transaction(from_addr=w['public_key'], script='let x=1', premium=1, nonce=1)
+    tx4.sign(w)
+    assert mp.add_tx(tx4) is False
+
+
+def test_queue_modes(tmp_path):
+    w1 = create_wallet(tmp_path)
+    w2 = create_wallet(tmp_path)
+    balances = {w1['public_key']: 100, w2['public_key']: 100}
+    # premium mode
+    mp = Mempool(balances=balances, mode='premium')
+    tx1 = Transaction(from_addr=w1['public_key'], script='let a=1', premium=1, nonce=1)
+    tx1.sign(w1)
+    mp.add_tx(tx1)
+    tx2 = Transaction(from_addr=w2['public_key'], script='let a=1', premium=5, nonce=1)
+    tx2.sign(w2)
+    mp.add_tx(tx2)
+    ordered = mp.pop_for_block(2)
+    assert [t.premium for t in ordered] == [5, 1]
+    # fifo mode
+    mp2 = Mempool(balances=balances, mode='fifo')
+    tx3 = Transaction(from_addr=w1['public_key'], script='let a=1', premium=1, nonce=1)
+    tx3.sign(w1)
+    mp2.add_tx(tx3)
+    tx4 = Transaction(from_addr=w2['public_key'], script='let a=1', premium=5, nonce=1)
+    tx4.sign(w2)
+    mp2.add_tx(tx4)
+    ordered2 = mp2.pop_for_block(2)
+    assert [t.premium for t in ordered2] == [1, 5]
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import tempfile
+import hashlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from blockchain_demo import wallet
+from blockchain_demo.transaction import Transaction
+from blockchain_demo.mempool import Mempool
+from blockchain_demo.config import Config
+
+
+def create_wallet():
+    td = tempfile.TemporaryDirectory()
+    path = os.path.join(td.name, 'w.json')
+    wallet.generate_wallet(path)
+    return wallet.load_wallet(path)
+
+
+def sign_tx(tx, w):
+    tx.sign(w)
+    return tx
+
+
+def test_premium_validation():
+    w = create_wallet()
+    cfg = Config(MIN_PREMIUM=5)
+    tx = Transaction(from_addr=w['public_key'], script='let a=1', premium=1, nonce=1)
+    sign_tx(tx, w)
+    assert not tx.is_premium_valid(cfg)
+    mp = Mempool(balances={w['public_key']: 10}, mode='premium', cfg=cfg)
+    mp.nonces[w['public_key']] = 0
+    assert not mp.add_tx(tx)
+
+
+def test_nonce_monotonicity():
+    w = create_wallet()
+    tx = Transaction(from_addr=w['public_key'], script='let a=1', premium=1, nonce=1)
+    sign_tx(tx, w)
+    assert not tx.is_nonce_valid(1)
+    mp = Mempool(balances={w['public_key']: 10})
+    mp.nonces[w['public_key']] = 1
+    assert not mp.add_tx(tx)
+
+
+def test_balance_validation():
+    w = create_wallet()
+    tx = Transaction(from_addr=w['public_key'], script='let a=1', premium=10, nonce=1)
+    sign_tx(tx, w)
+    assert not tx.has_sufficient_balance({w['public_key']: 5})
+    mp = Mempool(balances={w['public_key']: 5})
+    mp.nonces[w['public_key']] = 0
+    assert not mp.add_tx(tx)
+
+
+def test_canonical_hash():
+    w = create_wallet()
+    tx = Transaction(from_addr=w['public_key'], script='let x=1', premium=2, nonce=3)
+    sign_tx(tx, w)
+    from blockchain_demo.utils import canonical_bytes
+    h1 = tx.hash()
+    h2 = hashlib.sha256(canonical_bytes({
+        "from": w['public_key'],
+        "script": 'let x=1',
+        "premium": 2,
+        "nonce": 3,
+    })).hexdigest()
+    assert h1 == h2
+


### PR DESCRIPTION
## Summary
- add canonical JSON helper for consistent hashing
- validate premium, nonce order and balance in `Transaction`
- enforce validation when adding to `Mempool`
- integrate canonical hashing in `Block` and `Transaction`
- add tests for transaction validation and canonical hashes
- merge updates from `main` with mempool admission tests
- cherry-pick mempool changes from 21ce763 and adapt comments

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68791de73d088325baf14fc264bed56b